### PR TITLE
pypdf instead of pypdf4, natsort dep setuptools added (was distutils)

### DIFF
--- a/install.py
+++ b/install.py
@@ -181,32 +181,57 @@ def do_dependency_checks():
 
     # not checking natsort version
 
-
     ##########################################################
-    # PyPDF4
+    # setuptools (dependency of natsort)
     ##########################################################
     try:
-        import PyPDF4
+        import setuptools
     except ImportError as msg:
         installed = pip_install(
-            "PyPDF4", "PyPDF4 could not be detected.\nError: {0}".format(msg)
+            "setuptools", "setuptools could not be detected.\nError: {0}".format(msg)
         )
 
         if installed:
             # try to import it again
             try:
-                import PyPDF4
+                import setuptools
             except ImportError as msg:
-                print("Sorry, please install PyPDF4.")
+                print("Sorry, please install setuptools.")
                 print("Error: {0}".format(msg))
                 exit(1)
         else:
-            print("Sorry, please install PyPDF4.")
+            print("Sorry, please install setuptools.")
             print("Error: {0}".format(msg))
             exit(1)
-    print("Found PyPDF4")
+    print("Found setuptools")
 
     # not checking natsort version
+
+    ##########################################################
+    # PyPDF4
+    ##########################################################
+    try:
+        import pypdf
+    except ImportError as msg:
+        installed = pip_install(
+            "pypdf", "pypdf could not be detected.\nError: {0}".format(msg)
+        )
+
+        if installed:
+            # try to import it again
+            try:
+                import pypdf
+            except ImportError as msg:
+                print("Sorry, please install pypdf.")
+                print("Error: {0}".format(msg))
+                exit(1)
+        else:
+            print("Sorry, please install pypdf.")
+            print("Error: {0}".format(msg))
+            exit(1)
+    print("Found pypdf")
+
+    # not checking pypdf version
 
     print()
     print("All set!")

--- a/pechaprinter.pyw
+++ b/pechaprinter.pyw
@@ -7,11 +7,10 @@ from PyQt5 import QtWidgets, QtGui
 from PyQt5.QtCore import Qt
 from PyQt5.uic import loadUi
 from PIL import Image
-from PyPDF4 import PdfFileMerger
+from pypdf import PdfWriter
 from natsort import natsorted
 import pathlib
 import shutil
-import time
 
 BASEDIR = os.path.dirname(os.path.abspath(__file__))
 TEMPDIR =  pathlib.Path(pathlib.Path.home(), 'Documents', '~temp')
@@ -288,7 +287,7 @@ class Pecha(object):
             if file.endswith(".pdf"):
                 pdfs.append(f'{TEMPDIRstacks}{file}')
 
-        merger = PdfFileMerger()
+        merger = PdfWriter()
 
         for pdf in pdfs:
             print(pdf)

--- a/pechaprinter.pyw
+++ b/pechaprinter.pyw
@@ -132,7 +132,7 @@ class Pecha(object):
             [
                 self.pdftoppmLocation,
                 '-r',
-                '300',
+                '600',
                 self.inputLocation,
                 TEMPDIRimgs,
             ],
@@ -275,27 +275,36 @@ class Pecha(object):
             finalPage.save(f'{TEMPDIRstacks}{i:04}.pdf')
 
     def savePdf(self):
-        self.message = 'Saving images'
-        print(self.message)
+        message = 'Saving images'
+        print(message)
 
-        self.outputPath = f'{self.outputLocation}{self.outputName}.pdf'
+        outputPath_odd = f'{self.outputLocation}{self.outputName}_odd.pdf'
+        outputPath_even = f'{self.outputLocation}{self.outputName}_even.pdf'
+
         # delete previous to replace
-        if os.path.exists(self.outputPath):
-            os.remove(self.outputPath)
+        for p in [outputPath_even, outputPath_odd]:
+            if os.path.exists(p):
+                os.remove(p)
+
         pdfs = []
         for file in os.listdir(TEMPDIRstacks):
             if file.endswith(".pdf"):
                 pdfs.append(f'{TEMPDIRstacks}{file}')
 
-        merger = PdfWriter()
-
-        for pdf in pdfs:
+        merger_odd = PdfWriter()
+        merger_even = PdfWriter()
+        for i, pdf in enumerate(sorted(pdfs)):
             print(pdf)
-            merger.append(pdf)
+            if i & 1 == 0:  # even page, not even number
+                merger_even.append(pdf)
+            else:
+                merger_odd.append(pdf)
 
         # save pdf
-        merger.write(self.outputPath)
-        merger.close()
+        merger_even.write(outputPath_even)
+        merger_even.close()
+        merger_odd.write(outputPath_odd)
+        merger_odd.close()
 
 class Ui(QtWidgets.QDialog):
     def __init__(self):

--- a/pechaprinter.pyw
+++ b/pechaprinter.pyw
@@ -6,7 +6,7 @@ import subprocess
 from PyQt5 import QtWidgets, QtGui
 from PyQt5.QtCore import Qt
 from PyQt5.uic import loadUi
-from PIL import Image
+from PIL import Image, ImageDraw
 from pypdf import PdfWriter
 from natsort import natsorted
 import pathlib
@@ -17,6 +17,7 @@ TEMPDIR =  pathlib.Path(pathlib.Path.home(), 'Documents', '~temp')
 TEMPDIRroot = f'{TEMPDIR}{os.sep}'
 TEMPDIRimgs = f'{TEMPDIRroot}imgs{os.sep}'
 TEMPDIRstacks = f'{TEMPDIRroot}stacks{os.sep}'
+debug = False
 
 class Pecha(object):
     def __init__(self):
@@ -38,7 +39,7 @@ class Pecha(object):
         self.tempJpgsNumber = 0
         self.totalPages = 0
         self.difference = 0
-        self.aspectRatio = 3508 / 827
+        self.aspectRatio = 7016 / 2339
         self.optimalWidth = 0
         self.optimalHeight = 0
         self.optimalHeightTotal = 0
@@ -154,9 +155,9 @@ class Pecha(object):
     def resizeImages(self):
         if self.outputSize == "A4":
             self.optimalWidth, self.optimalHeight, self.optimalHeightTotal = (
-                3508,
-                827,
-                2481,
+                7961,
+                2339,
+                7016,
             )
         elif self.outputSize == "A3":
             self.optimalWidth, self.optimalHeight, self.optimalHeightTotal = (
@@ -272,6 +273,15 @@ class Pecha(object):
                     finalPage.paste(self.imageStacks[2][i], (0, 0))
                     pass
                 pass
+            if debug:
+                draw = ImageDraw.Draw(finalPage)
+                w, h = finalPage.size
+                lines = [
+                    ((0, h/3), (w, h/3)),
+                    ((0, (h/3)*2), (w, (h/3)*2))
+                ]
+                for l in lines:
+                    draw.line(l, fill='red', width=3)
             finalPage.save(f'{TEMPDIRstacks}{i:04}.pdf')
 
     def savePdf(self):


### PR DESCRIPTION
pypdf4 is not supported anymore, but pypdf is active once again. distutils is deprecated since pypthon3.10, but included in setuptools.

